### PR TITLE
Revert "chore(travis): whitelist greenkeeper branches"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: npm
 branches:
   only:
     - master
-    - /^greenkeeper/.*$/
 notifications:
   email:
     recipients:


### PR DESCRIPTION
This reverts commit bc6e78de98013619bd377eef88312fa403a5328e.